### PR TITLE
correct major issue on filescanner.

### DIFF
--- a/yamj3-filescanner/src/main/java/org/yamj/filescanner/model/Library.java
+++ b/yamj3-filescanner/src/main/java/org/yamj/filescanner/model/Library.java
@@ -25,6 +25,7 @@ package org.yamj.filescanner.model;
 import java.io.File;
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -59,7 +60,7 @@ public class Library implements Serializable {
         this.description = "";
         this.statistics = new Statistics();
         this.directories = new HashMap<>(1);
-        this.directoryStatus = new HashMap<>(1);
+        this.directoryStatus = new LinkedHashMap<>(1);
         importDTO = new ImportDTO();
         this.scanningComplete = new AtomicBoolean(Boolean.FALSE);
         this.sendingComplete = new AtomicBoolean(Boolean.FALSE);

--- a/yamj3-filescanner/src/main/java/org/yamj/filescanner/service/LibrarySendScheduler.java
+++ b/yamj3-filescanner/src/main/java/org/yamj/filescanner/service/LibrarySendScheduler.java
@@ -120,7 +120,7 @@ public class LibrarySendScheduler {
                 }
 
                 // Don't stop sending until the scanning is completed and there are no running tasks
-                if (library.isScanningComplete() && runningCount.get() > 0) {
+                if (library.isScanningComplete() && runningCount.get() <= 0) {
                     // When we reach this point we should have completed the library sending
                     LOG.info("Sending complete for {}", library.getImportDTO().getBaseDirectory());
                     library.setSendingComplete(Boolean.TRUE);
@@ -139,8 +139,10 @@ public class LibrarySendScheduler {
     private boolean checkStatus(Library library, Future<StatusType> statusType, String directory) throws InterruptedException, ExecutionException {
         boolean sendStatus;
 
+        
         if (statusType.isDone()) {
             StatusType processingStatus = statusType.get();
+            
             if (processingStatus == StatusType.NEW) {
                 LOG.info("    Sending '{}' to core for processing.", directory);
                 sendStatus = sendToCore(library, directory);
@@ -184,7 +186,7 @@ public class LibrarySendScheduler {
             return Boolean.TRUE;
         }
 
-        LOG.debug("Sending #{}: {}", runningCount.incrementAndGet(), sendDir);
+        LOG.info("Sending #{}: {}", runningCount.incrementAndGet(), sendDir);
 
         ApplicationContext appContext = ApplicationContextProvider.getApplicationContext();
         SendToCore stc = (SendToCore) appContext.getBean("sendToCore");


### PR DESCRIPTION
- Library was marked as sending even if child directory is not send.
- Library was not send in the good order. Library G:\film was send after G\film\charmder. So the table stage_directory was inconsistent.

ref YAMJ/yamj-v3#239